### PR TITLE
Updates to open the vault by default, instead of clicking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ ENV CUSTOM_PORT="8080" \
 
 # Add local files
 COPY root/ /
+
+# Add obsidian config to configure known vaults
+# You still need to click once on "all community plugins" and then store the image with 'docker commit <container> obsidian:latest'
+COPY obsidian.json /root/.config/obsidian/
 EXPOSE 8080 8443
 VOLUME ["/config","/vaults"]
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+Fork from https://github.com/XpiritBV/obsidian-remote.git to add a preconfigured vault path to it and have a way to get the vault auto started as much as possible.
+
+The changes in this repo make:
+- the container start mount the vault in the /config folder (mounted)
+
+To be able to use it for automation (we run "Export to HTML" using Selenium for example), there is still one manual action after building the Dockerfile:
+- Run the image once
+- Connect to the VNC setup with a browser to https://localhost:8080 (see the file `run-docker-process.ps1`)
+- Click on "Trust community plugins", this will execute the community plugins, for us we need this for the DataView plugin
+- Now store the image changes in the container by:
+  - Exiting the interactive session (CTRL + P + Q), LEAVE THE CONTAINER RUNNING
+  - Commit the changes to the image: `docker commit <container-id> vaultSnapShot`
+- Now you can push the container as is (with the trust config, we can't find where that is stored) into a Container Registry you choose.
+- Next time you run this container with the normal mounts, the Obsidian vault will be opened by default.
+
 # obsidian-remote
 
 This docker image allows you to run [obsidian](https://obsidian.md/) in docker as a container and access it via your web browser.
@@ -278,6 +293,3 @@ docker run --rm -it `
 Click on the circle to the left side of your browser window. In there you will find a textbox for updating the remote clipboard or copying from it.
 
 ![image](https://user-images.githubusercontent.com/1399443/202805847-a87e2c7c-a5c6-4dea-bbae-4b25b4b5866a.png)
-
-
-

--- a/obsidian.json
+++ b/obsidian.json
@@ -1,0 +1,1 @@
+{"vaults":{"2a8e3d37e8e05fc3":{"path":"/config","ts":1706867714593,"open":true}}}

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,7 @@
-sudo /usr/bin/obsidian --no-sandbox --no-xshm --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer
+# testing if we get this output
+if [ -d "/config" ]; then
+    echo "**** /config exists. ****"
+else
+    echo "**** /config does not exist. ****"
+fi
+sudo /usr/bin/obsidian "/config" --no-sandbox --no-xshm --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-/startpulse.sh &
+#/startpulse.sh &
 /usr/bin/openbox-session > /dev/null 2>&1

--- a/run-docker-process.ps1
+++ b/run-docker-process.ps1
@@ -1,0 +1,24 @@
+$vaultPath = "C:\Users\RobBos\Code\Repos\GitHub\XpiritBV\portfolio"
+
+# comment for faster reruns
+docker build -t obsidian-remote .
+
+docker run --rm -it `
+  -v ${vaultPath}:/vaults `
+  -v ${vaultPath}:/config `
+  -p 8080:8080 `
+  obsidian-remote #vault3
+
+# after returning , get the container id so we can kill it
+$containerID = docker ps -f "ancestor=obsidian-remote" --format "{{.ID}}" 2>$null
+
+# ask it the container should be killed
+$shouldKill = Read-Host "Do you want to kill the container? (y/n)"
+if ($shouldKill -eq "y") {
+    Write-Host "Killing container with ID ${containerID}"
+    # kill the container
+    docker kill $containerID
+}
+else {
+    Write-Host "Stopping script, container is still running"
+}


### PR DESCRIPTION
Published manually (see readme) to https://github.com/orgs/XpiritBV/packages/container/package/obsidian-remote so it can be pulled with:
``` pwsh
docker pull ghcr.io/xpiritbv/obsidian-remote:latest
```